### PR TITLE
Fixed an issue where a tool can't be netstandard

### DIFF
--- a/Tool/Tool.csproj
+++ b/Tool/Tool.csproj
@@ -11,7 +11,7 @@
 	<Description>Command Line Utility to create Swagger specifications using reflection. This project is not intended to be used for .Net Core projects.</Description>
 	<RepositoryUrl>https://github.com/valadas/WebApiToOpenApiReflector</RepositoryUrl>
 	<ToolCommandName>webapi-to-openapi-reflector</ToolCommandName>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 	<RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -99,7 +99,6 @@ class Build : NukeBuild
         {
             var frameworks = new List<string>
             {
-                "netstandard2.1",
                 "net8.0",
                 "net9.0",
             };
@@ -115,8 +114,7 @@ class Build : NukeBuild
                         .SetFileVersion(GitVersion.MajorMinorPatch)
                         .SetInformationalVersion(GitVersion.FullSemVer)
                         .SetOutput(artifactsDirectory)
-                        .SetFramework(framework)
-                        .DisablePublishSingleFile());
+                        .SetFramework(framework));
                 });
             }
             else
@@ -141,8 +139,7 @@ class Build : NukeBuild
                             .EnablePublishSingleFile()
                             .SetRuntime(runtimeIdentifier)
                             .SetOutput(artifactsDirectory / runtimeIdentifier)
-                            .SetFramework(framework)
-                            .DisablePublishSingleFile());
+                            .SetFramework(framework));
                     });
                 });
             }


### PR DESCRIPTION
Fixed an issue where a tool can't be netstandard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined publishing process by removing support for `netstandard2.1`, focusing on `net8.0` and `net9.0`.
	- Introduced runtime identifiers for improved compatibility across different operating systems.

- **Bug Fixes**
	- Adjusted method calls in the build process to enhance functionality and maintain consistency.

- **Documentation**
	- Updated internal documentation to reflect changes in framework support and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->