### PR TITLE
Bumped nuke to v9.0.4

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -22,7 +22,6 @@ using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 using Octokit;
 using static Nuke.Common.EnvironmentInfo;
-using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.IO.PathConstruction;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 using static Nuke.Common.Tools.NuGet.NuGetTasks;

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="9.0.1" />
+    <PackageReference Include="Nuke.Common" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.304",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Bumped nuke to v9.0.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling: bumped Nuke.Common to 9.0.4 and aligned the .NET SDK to 9.0.304 for improved stability and compatibility.
  * Cleaned up build script imports to remove unnecessary references and reduce clutter.
  * These changes are internal to the build process and do not affect end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->