### PR TITLE
Fixed some issues with nuget publishing

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -241,12 +241,15 @@ class Build : NukeBuild
         {
             var package = nugetDirectory.GlobFiles("*.nupkg").First();
             Serilog.Log.Information($"Publishing NuGet package: {package}");
-            Serilog.Log.Information($"Using NuGet API Key: {NugetApiKey.Substring(0, Math.Min(8, NugetApiKey.Length))}...");
             
             try
             {
-                // Use dotnet nuget push instead of NuGetPush for better cross-platform compatibility
-                DotNet($"nuget push \"{package}\" --api-key {NugetApiKey} --source https://api.nuget.org/v3/index.json --skip-duplicate");
+                DotNetNuGetPush(s => s
+                    .SetTargetPath(package)
+                    .SetApiKey(NugetApiKey)
+                    .SetSource("https://api.nuget.org/v3/index.json")
+                    .SetSkipDuplicate(true)
+                );
                 Serilog.Log.Information("Successfully published to NuGet!");
             }
             catch (Exception ex)


### PR DESCRIPTION
Nuget publishing failed with no great error feedback. Trying this change to see if it improves it and allows further debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Automatically regenerates help output and injects it into README.
  * Adds clearer start/success/error logs during docs generation; treats common help exit codes (129 or 1) as non-fatal.

* **Chores**
  * Adds verbose telemetry and detailed logging around package creation (versions, output directory, produced package list/count).
  * Switches NuGet publishing to a cross-platform CLI push, skipping duplicate-package errors, with clearer publish logs and explicit error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->