### PR TITLE
Use ubuntu-2204 instead of latest

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -30,7 +30,7 @@ using System.Text.RegularExpressions;
 
 [GitHubActions(
     "PR Validation",
-    GitHubActionsImage.UbuntuLatest,
+    GitHubActionsImage.Ubuntu2204,
     OnPullRequestBranches = new[] {"*"},
     OnPushBranches = new[] {"main", "develop"},
     InvokedTargets = new[] {nameof(Compile)},
@@ -40,7 +40,7 @@ using System.Text.RegularExpressions;
 )]
 [GitHubActions(
     "Release",
-    GitHubActionsImage.UbuntuLatest,
+    GitHubActionsImage.Ubuntu2204,
     OnPushBranches = new[] {"main", "release/*"},
     InvokedTargets = new[] {nameof(ReleaseToGithub), nameof(ReleaseToNuget) },
     ImportSecrets = new[] {nameof(GitHubToken), nameof(NugetApiKey)},


### PR DESCRIPTION
This should cover the missing mono on latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI runners to Ubuntu 22.04 for PR Validation and Release workflows to align with current infrastructure and improve stability.
  - Ensures consistent build environment across pipelines, reducing variability and potential runtime discrepancies.
  - No changes to features, behavior, or user interface; application functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->